### PR TITLE
Refactor: move auth state to AuthProvider context

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,5 +5,12 @@
 import {AppRegistry} from 'react-native';
 import App from './src/App';
 import {name as appName} from './app.json';
+import {AuthProvider} from './src/contexts/AuthContext';
 
-AppRegistry.registerComponent(appName, () => App);
+const Root = () => (
+  <AuthProvider>
+    <App />
+  </AuthProvider>
+);
+
+AppRegistry.registerComponent(appName, () => Root);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,37 +1,34 @@
 import React, {useEffect, useState} from 'react';
 import {StyleSheet, Text} from 'react-native';
 import SpotifyAuthButton from './components/SpotifyAuthButton';
-import {SpotifyAuth} from './types/SpotifyAuth';
+import {useAuth} from './contexts/AuthContext';
 import {SpotifyPlaylist} from './types/SpotifyPlaylist';
 import {getPlaylists} from './services/playlistService';
 import Playlist from './components/SpotifyPlaylist';
 
 function App(): React.JSX.Element {
-  const [spotifyAuth, setSpotifyAuth] = useState<SpotifyAuth | null>(null);
+  const {auth, isAuthenticated} = useAuth();
   const [playlists, setPlaylists] = useState<SpotifyPlaylist[] | null>(null);
 
   useEffect(() => {
     const fetchPlaylists = async () => {
-      if (!spotifyAuth?.accessToken) {
+      if (!isAuthenticated) {
         return;
       }
-      const data = await getPlaylists(spotifyAuth.accessToken);
+      const data = await getPlaylists(auth!.accessToken);
       setPlaylists(data);
     };
-    if (spotifyAuth?.accessToken) {
+    if (isAuthenticated) {
       fetchPlaylists();
     } else {
       setPlaylists(null);
     }
-  }, [spotifyAuth]);
+  }, [auth, isAuthenticated]);
 
   return (
     <>
       <Text style={styles.title}>SuperSetList</Text>
-      <SpotifyAuthButton
-        spotifyAuth={spotifyAuth}
-        setSpotifyAuth={setSpotifyAuth}
-      />
+      <SpotifyAuthButton />
       {playlists &&
         playlists.map((playlist, playlistIdx) => {
           return (

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [Unreleased]
+
+### Changed
+
+- Refactor: move auth state to AuthProvider context [#1](https://github.com/aaronskiba/SuperSetList/pull/1)

--- a/src/components/SpotifyAuthButton.tsx
+++ b/src/components/SpotifyAuthButton.tsx
@@ -1,23 +1,16 @@
 import {Pressable, StyleSheet, Text} from 'react-native';
-import {handleSpotifyAuth} from '../services/authService';
-import {SpotifyAuthButtonProps} from '../types/SpotifyAuthButtonProps';
+import {useAuth} from '../contexts/AuthContext';
 
-export default function SpotifyAuthButton({
-  spotifyAuth,
-  setSpotifyAuth,
-}: SpotifyAuthButtonProps) {
-  const updateSpotifyAuth = async () => {
-    if (spotifyAuth) {
-      setSpotifyAuth(null);
-    } else {
-      const authData = await handleSpotifyAuth();
-      setSpotifyAuth(authData);
-    }
+export default function SpotifyAuthButton() {
+  const {login, logout, isAuthenticated} = useAuth();
+
+  const handleOnPress = () => {
+    isAuthenticated ? logout() : login();
   };
   return (
-    <Pressable onPress={updateSpotifyAuth} style={styles.loginButton}>
+    <Pressable onPress={handleOnPress} style={styles.loginButton}>
       <Text style={{color: 'black', fontWeight: 'bold'}}>
-        {spotifyAuth ? 'Logout From Spotify' : 'Connect to Spotify Account'}
+        {isAuthenticated ? 'Logout From Spotify' : 'Connect to Spotify Account'}
       </Text>
     </Pressable>
   );

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,47 @@
+import {createContext, useContext, useState, ReactNode, FC} from 'react';
+import {SpotifyAuth} from '../types/SpotifyAuth';
+import {handleSpotifyAuth} from '../services/authService';
+
+interface AuthContextType {
+  auth: SpotifyAuth | null;
+  login: () => void | Promise<void>;
+  logout: () => void;
+  isAuthenticated: boolean;
+}
+
+interface AuthProviderProps {
+  children: ReactNode;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const AuthProvider: FC<AuthProviderProps> = ({children}) => {
+  const [auth, setAuth] = useState<SpotifyAuth | null>(null);
+
+  const login = async () => {
+    try {
+      const authData: SpotifyAuth = await handleSpotifyAuth();
+      setAuth(authData);
+    } catch (err) {
+      console.error('Spotify login failed: ', err);
+    }
+  };
+
+  const logout = () => setAuth(null);
+
+  const isAuthenticated = !!auth?.accessToken;
+
+  return (
+    <AuthContext.Provider value={{auth, login, logout, isAuthenticated}}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = (): AuthContextType => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};

--- a/src/types/SpotifyAuthButtonProps.ts
+++ b/src/types/SpotifyAuthButtonProps.ts
@@ -1,6 +1,0 @@
-import {SpotifyAuth} from './SpotifyAuth';
-
-export type SpotifyAuthButtonProps = {
-  spotifyAuth: SpotifyAuth | null;
-  setSpotifyAuth: (auth: SpotifyAuth | null) => void;
-};


### PR DESCRIPTION
## Refactor: move auth state to AuthProvider context
`index.js`
- Wrapped `<App>` with `<AuthProvider>`

`src/App.tsx` and `src/components/SpotifyAuthButton.tsx`
- Refactor: handle auth state with AuthProvider context

`src/contexts/AuthContext.tsx`
- Created `AuthContext` to manage Spotify authentication globally
- Created custom `useAuth()` hook to expose auth, `isAuthenticated` boolean, as well as `login()` and `logout()`

## Create CHANGELOG.md
- Added this PR as an initial entry