### PR TITLE
Refactor Playlist Components (and Rename `SpotifyAuthButton`)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,40 +1,16 @@
-import React, {useEffect, useState} from 'react';
 import {StyleSheet, Text} from 'react-native';
 import SpotifyAuthButton from './components/SpotifyAuthButton';
 import {useAuth} from './contexts/AuthContext';
-import {SpotifyPlaylist} from './types/SpotifyPlaylist';
-import {getPlaylists} from './services/playlistService';
-import Playlist from './components/SpotifyPlaylist';
+import PlaylistList from './components/PlaylistList';
 
 function App(): React.JSX.Element {
-  const {auth, isAuthenticated} = useAuth();
-  const [playlists, setPlaylists] = useState<SpotifyPlaylist[] | null>(null);
-
-  useEffect(() => {
-    const fetchPlaylists = async () => {
-      if (!isAuthenticated) {
-        return;
-      }
-      const data = await getPlaylists(auth!.accessToken);
-      setPlaylists(data);
-    };
-    if (isAuthenticated) {
-      fetchPlaylists();
-    } else {
-      setPlaylists(null);
-    }
-  }, [auth, isAuthenticated]);
+  const isAuthenticated = useAuth();
 
   return (
     <>
       <Text style={styles.title}>SuperSetList</Text>
       <SpotifyAuthButton />
-      {playlists &&
-        playlists.map((playlist, playlistIdx) => {
-          return (
-            <Playlist key={playlistIdx} spotifyPlaylist={playlist}></Playlist>
-          );
-        })}
+      {isAuthenticated && <PlaylistList />}
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import {StyleSheet, Text} from 'react-native';
-import SpotifyAuthButton from './components/SpotifyAuthButton';
+import AuthButton from './components/AuthButton';
 import {useAuth} from './contexts/AuthContext';
 import PlaylistList from './components/PlaylistList';
 
@@ -9,7 +9,7 @@ function App(): React.JSX.Element {
   return (
     <>
       <Text style={styles.title}>SuperSetList</Text>
-      <SpotifyAuthButton />
+      <AuthButton />
       {isAuthenticated && <PlaylistList />}
     </>
   );

--- a/src/components/AuthButton.tsx
+++ b/src/components/AuthButton.tsx
@@ -1,7 +1,7 @@
 import {Pressable, StyleSheet, Text} from 'react-native';
 import {useAuth} from '../contexts/AuthContext';
 
-export default function SpotifyAuthButton() {
+export default function AuthButton() {
   const {login, logout, isAuthenticated} = useAuth();
 
   const handleOnPress = () => {

--- a/src/components/PlaylistItem.tsx
+++ b/src/components/PlaylistItem.tsx
@@ -1,9 +1,7 @@
 import {Image, StyleSheet, Text, View} from 'react-native';
 import {SpotifyPlaylistProps} from '../types/SpotifyPlaylistProps';
 
-export default function SpotifyPlaylist({
-  spotifyPlaylist,
-}: SpotifyPlaylistProps) {
+export default function PlaylistItem({spotifyPlaylist}: SpotifyPlaylistProps) {
   return (
     <View style={styles.container}>
       <Image

--- a/src/components/PlaylistList.tsx
+++ b/src/components/PlaylistList.tsx
@@ -1,0 +1,34 @@
+import {useEffect, useState} from 'react';
+import {SpotifyPlaylist} from '../types/SpotifyPlaylist';
+import {getPlaylists} from '../services/playlistService';
+import PlaylistItem from './PlaylistItem';
+import {useAuth} from '../contexts/AuthContext';
+
+export default function PlaylistList() {
+  const [playlists, setPlaylists] = useState<SpotifyPlaylist[] | null>(null);
+  const {auth, isAuthenticated} = useAuth();
+
+  useEffect(() => {
+    const fetchPlaylists = async () => {
+      if (!isAuthenticated) {
+        return;
+      }
+      const data = await getPlaylists(auth!.accessToken);
+      setPlaylists(data);
+    };
+    if (isAuthenticated) {
+      fetchPlaylists();
+    } else {
+      setPlaylists(null);
+    }
+  }, [auth, isAuthenticated]);
+
+  return (
+    <>
+      {playlists &&
+        playlists.map((playlist, playlistIdx) => {
+          return <PlaylistItem key={playlistIdx} spotifyPlaylist={playlist} />;
+        })}
+    </>
+  );
+}

--- a/src/components/PlaylistList.tsx
+++ b/src/components/PlaylistList.tsx
@@ -6,22 +6,20 @@ import {useAuth} from '../contexts/AuthContext';
 
 export default function PlaylistList() {
   const [playlists, setPlaylists] = useState<SpotifyPlaylist[] | null>(null);
-  const {auth, isAuthenticated} = useAuth();
+  const {auth} = useAuth();
+  const accessToken = auth?.accessToken;
 
   useEffect(() => {
     const fetchPlaylists = async () => {
-      if (!isAuthenticated) {
+      if (!accessToken) {
+        setPlaylists(null);
         return;
       }
-      const data = await getPlaylists(auth!.accessToken);
+      const data = await getPlaylists(accessToken);
       setPlaylists(data);
     };
-    if (isAuthenticated) {
-      fetchPlaylists();
-    } else {
-      setPlaylists(null);
-    }
-  }, [auth, isAuthenticated]);
+    fetchPlaylists();
+  }, [accessToken]);
 
   return (
     <>


### PR DESCRIPTION
Refactor Playlist Components 1a2b01d1103a93204d5788526a45b02fa95a52e3
- Moved PlaylistList logic from `src/App.tsx` to newly created `src/components/PlaylistList.tsx`
- Renamed `src/components/Playlist.tsx` to `src/components/PlaylistItem.tsx`

Refactor `useEffect()` in `PlaylistList.tsx` 68ba3a9453e7d4394701b6d85871b3ed41e47e63
- Simplified logic

Rename `SpotifyAuthButton` -> `AuthButton` 138e0a944b973813445ddc832ed0e384ac832f33
- Renamed both the filename and function name along with their references

