### PR TITLE
Initial Spotify Tracks Implementation + Refactoring

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import {StyleSheet, Text} from 'react-native';
 import AuthButton from './components/AuthButton';
 import {useAuth} from './contexts/AuthContext';
-import PlaylistList from './components/PlaylistList';
+import Playlists from './components/Playlists';
 
 function App(): React.JSX.Element {
   const isAuthenticated = useAuth();
@@ -10,7 +10,7 @@ function App(): React.JSX.Element {
     <>
       <Text style={styles.title}>SuperSetList</Text>
       <AuthButton />
-      {isAuthenticated && <PlaylistList />}
+      {isAuthenticated && <Playlists />}
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,18 +10,22 @@ function App(): React.JSX.Element {
   const isAuthenticated = useAuth();
   const [playlist, setPlaylist] = useState<SpotifyPlaylist | null>(null);
 
+  const renderConditionalContent = () => {
+    if (!isAuthenticated) return null;
+    return playlist ? (
+      <SpotifyTracks
+        spotifyPlaylist={playlist}
+        unselectPlaylist={() => setPlaylist(null)}
+      />
+    ) : (
+      <Playlists selectPlaylist={(p: SpotifyPlaylist) => setPlaylist(p)} />
+    );
+  };
+
   return (
     <>
       <Text style={styles.title}>SuperSetList</Text>
-      {isAuthenticated &&
-        (playlist ? (
-          <SpotifyTracks
-            spotifyPlaylist={playlist}
-            unselectPlaylist={() => setPlaylist(null)}
-          />
-        ) : (
-          <Playlists selectPlaylist={(p: SpotifyPlaylist) => setPlaylist(p)} />
-        ))}
+      {renderConditionalContent()}
       <AuthButton />
     </>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,28 @@
+import {useState} from 'react';
 import {StyleSheet, Text} from 'react-native';
 import AuthButton from './components/AuthButton';
 import {useAuth} from './contexts/AuthContext';
+import {SpotifyPlaylist} from './types/SpotifyPlaylist';
 import Playlists from './components/Playlists';
+import SpotifyTracks from './components/SpotifyTracks';
 
 function App(): React.JSX.Element {
   const isAuthenticated = useAuth();
+  const [playlist, setPlaylist] = useState<SpotifyPlaylist | null>(null);
 
   return (
     <>
       <Text style={styles.title}>SuperSetList</Text>
+      {isAuthenticated &&
+        (playlist ? (
+          <SpotifyTracks
+            spotifyPlaylist={playlist}
+            unselectPlaylist={() => setPlaylist(null)}
+          />
+        ) : (
+          <Playlists selectPlaylist={(p: SpotifyPlaylist) => setPlaylist(p)} />
+        ))}
       <AuthButton />
-      {isAuthenticated && <Playlists />}
     </>
   );
 }

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -1,0 +1,23 @@
+import {Pressable, StyleSheet, Text} from 'react-native';
+import {BackButtonProps} from '../types/SpotifyPlaylistProps';
+
+export default function BackButton({unselectPlaylist}: BackButtonProps) {
+  return (
+    <Pressable onPress={unselectPlaylist} style={styles.loginButton}>
+      <Text style={{color: 'black', fontWeight: 'bold'}}>
+        {'Return to Playlists'}
+      </Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  loginButton: {
+    alignSelf: 'center',
+    alignItems: 'center',
+    backgroundColor: '#1ED760', // Spotify green color
+    padding: 10,
+    borderRadius: 8,
+    width: '95%',
+  },
+});

--- a/src/components/Playlist.tsx
+++ b/src/components/Playlist.tsx
@@ -1,18 +1,29 @@
-import {Image, StyleSheet, Text, View} from 'react-native';
+import {Image, Pressable, StyleSheet, Text, View} from 'react-native';
 import {SpotifyPlaylistProps} from '../types/SpotifyPlaylistProps';
 
-export default function Playlist({spotifyPlaylist}: SpotifyPlaylistProps) {
+export default function Playlist({
+  spotifyPlaylist,
+  selectPlaylist,
+}: SpotifyPlaylistProps) {
   return (
-    <View style={styles.container}>
-      <Image
-        source={{uri: spotifyPlaylist.images[0]?.url}}
-        style={{width: 100, height: 100}}
-      />
-      <View style={styles.textContainer}>
-        <Text style={styles.name}>{spotifyPlaylist.name}</Text>
-        <Text style={styles.description}>{spotifyPlaylist.description}</Text>
+    <Pressable
+      onPress={() => selectPlaylist(spotifyPlaylist)}
+      style={({pressed}) => [
+        {
+          backgroundColor: pressed ? 'rgb(210, 230, 255)' : 'white',
+        },
+      ]}>
+      <View style={styles.container}>
+        <Image
+          source={{uri: spotifyPlaylist.images[0]?.url}}
+          style={{width: 100, height: 100}}
+        />
+        <View style={styles.textContainer}>
+          <Text style={styles.name}>{spotifyPlaylist.name}</Text>
+          <Text style={styles.description}>{spotifyPlaylist.description}</Text>
+        </View>
       </View>
-    </View>
+    </Pressable>
   );
 }
 

--- a/src/components/Playlist.tsx
+++ b/src/components/Playlist.tsx
@@ -1,7 +1,7 @@
 import {Image, StyleSheet, Text, View} from 'react-native';
 import {SpotifyPlaylistProps} from '../types/SpotifyPlaylistProps';
 
-export default function PlaylistItem({spotifyPlaylist}: SpotifyPlaylistProps) {
+export default function Playlist({spotifyPlaylist}: SpotifyPlaylistProps) {
   return (
     <View style={styles.container}>
       <Image

--- a/src/components/Playlists.tsx
+++ b/src/components/Playlists.tsx
@@ -4,7 +4,7 @@ import {getPlaylists} from '../services/playlistService';
 import PlaylistItem from './PlaylistItem';
 import {useAuth} from '../contexts/AuthContext';
 
-export default function PlaylistList() {
+export default function Playlists() {
   const [playlists, setPlaylists] = useState<SpotifyPlaylist[] | null>(null);
   const {auth} = useAuth();
   const accessToken = auth?.accessToken;

--- a/src/components/Playlists.tsx
+++ b/src/components/Playlists.tsx
@@ -1,10 +1,11 @@
 import {useEffect, useState} from 'react';
 import {SpotifyPlaylist} from '../types/SpotifyPlaylist';
+import {SpotifyPlaylistsProps} from '../types/SpotifyPlaylistProps';
 import {getPlaylists} from '../services/playlistService';
 import Playlist from './Playlist';
 import {useAuth} from '../contexts/AuthContext';
 
-export default function Playlists() {
+export default function Playlists({selectPlaylist}: SpotifyPlaylistsProps) {
   const [playlists, setPlaylists] = useState<SpotifyPlaylist[] | null>(null);
   const {auth} = useAuth();
   const accessToken = auth?.accessToken;
@@ -24,8 +25,14 @@ export default function Playlists() {
   return (
     <>
       {playlists &&
-        playlists.map((playlist, playlistIdx) => {
-          return <Playlist key={playlistIdx} spotifyPlaylist={playlist} />;
+        playlists.map(playlist => {
+          return (
+            <Playlist
+              key={playlist.id}
+              spotifyPlaylist={playlist}
+              selectPlaylist={selectPlaylist}
+            />
+          );
         })}
     </>
   );

--- a/src/components/Playlists.tsx
+++ b/src/components/Playlists.tsx
@@ -1,7 +1,7 @@
 import {useEffect, useState} from 'react';
 import {SpotifyPlaylist} from '../types/SpotifyPlaylist';
 import {getPlaylists} from '../services/playlistService';
-import PlaylistItem from './PlaylistItem';
+import Playlist from './Playlist';
 import {useAuth} from '../contexts/AuthContext';
 
 export default function Playlists() {
@@ -25,7 +25,7 @@ export default function Playlists() {
     <>
       {playlists &&
         playlists.map((playlist, playlistIdx) => {
-          return <PlaylistItem key={playlistIdx} spotifyPlaylist={playlist} />;
+          return <Playlist key={playlistIdx} spotifyPlaylist={playlist} />;
         })}
     </>
   );

--- a/src/components/SpotifyTracks.tsx
+++ b/src/components/SpotifyTracks.tsx
@@ -1,0 +1,37 @@
+import {useEffect, useState} from 'react';
+import {SpotifyTrack} from '../types/SpotifyPlaylist';
+import Track from './Track';
+import {SpotifyTracksProps} from '../types/SpotifyPlaylistProps';
+import {getPlaylistTracks} from '../services/trackService';
+import {useAuth} from '../contexts/AuthContext';
+import BackButton from './BackButton';
+
+export default function SpotifyTracks({
+  spotifyPlaylist,
+  unselectPlaylist,
+}: SpotifyTracksProps) {
+  const [tracks, setTracks] = useState<SpotifyTrack[] | null>(null);
+  const {auth} = useAuth();
+  const accessToken = auth?.accessToken;
+  useEffect(() => {
+    const fetchTracks = async () => {
+      if (!accessToken) {
+        setTracks(null);
+        return;
+      }
+      const data = await getPlaylistTracks(spotifyPlaylist.id, accessToken);
+      setTracks(data);
+    };
+    fetchTracks();
+  }, [accessToken]);
+
+  return (
+    <>
+      <BackButton unselectPlaylist={unselectPlaylist} />
+      {tracks &&
+        tracks.map(track => {
+          return <Track key={track.id} spotifyTrack={track} />;
+        })}
+    </>
+  );
+}

--- a/src/components/Track.tsx
+++ b/src/components/Track.tsx
@@ -1,0 +1,38 @@
+import {Image, StyleSheet, Text, View} from 'react-native';
+import {SpotifyTrackProps} from '../types/SpotifyPlaylistProps';
+
+export default function Track({spotifyTrack}: SpotifyTrackProps) {
+  return (
+    <View style={styles.container}>
+      <Image
+        source={{uri: spotifyTrack.album.images[0]?.url}}
+        style={{width: 100, height: 100}}
+      />
+      <View style={styles.textContainer}>
+        <Text style={styles.name}>{spotifyTrack.name}</Text>
+        <Text style={styles.description}>{spotifyTrack.artists[0].name}</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row', // image and text side-by-side
+    borderColor: 'grey',
+    borderWidth: 1,
+  },
+  textContainer: {
+    flexDirection: 'column', // image and text side-by-side
+    paddingLeft: 10,
+  },
+  name: {
+    fontWeight: 'bold',
+    fontSize: 16,
+    marginBottom: 8,
+  },
+  description: {
+    color: '#666',
+    fontSize: 14,
+  },
+});

--- a/src/services/trackService.ts
+++ b/src/services/trackService.ts
@@ -1,0 +1,28 @@
+import {SpotifyTrack, SpotifyTrackResponse} from '../types/SpotifyPlaylist';
+
+export const getPlaylistTracks = async (
+  playlist_id: string,
+  accessToken: string,
+): Promise<SpotifyTrack[] | null> => {
+  try {
+    const response = await fetch(
+      `https://api.spotify.com/v1/playlists/${playlist_id}/tracks`,
+      {
+        headers: {
+          Authorization: 'Bearer ' + accessToken,
+        },
+      },
+    );
+    if (!response.ok) {
+      throw new Error(
+        `Spotify API error: ${response.status} ${response.statusText}`,
+      );
+    }
+    const data: SpotifyTrackResponse = await response.json();
+    const tracks = data.items.map(item => item.track);
+    return tracks;
+  } catch (e) {
+    console.error('Error fetching tracks: ', e);
+    return null;
+  }
+};

--- a/src/types/SpotifyPlaylist.ts
+++ b/src/types/SpotifyPlaylist.ts
@@ -1,12 +1,46 @@
+// https://developer.spotify.com/documentation/web-api/reference/
+
 export interface SpotifyPlaylistResponse {
   items: SpotifyPlaylist[];
   total: number;
 }
 
+export interface SpotifyTrackResponse {
+  items: {
+    track: SpotifyTrack;
+  }[];
+  total: number;
+}
+
 export interface SpotifyPlaylist {
   id: string;
+  external_urls: {
+    spotify: string;
+  };
   name: string;
   description: string;
-  tracks: {href: string; total: number};
-  images: {url: string}[];
+  tracks: {
+    href: string;
+    total: number;
+  };
+  images: {
+    url: string;
+  }[];
+}
+
+export interface SpotifyTrack {
+  id: string;
+  album: {
+    name: string;
+    images: {
+      url: string;
+    }[];
+  };
+  artists: {
+    name: string;
+  }[];
+  external_urls: {
+    spotify: string;
+  };
+  name: string;
 }

--- a/src/types/SpotifyPlaylistProps.ts
+++ b/src/types/SpotifyPlaylistProps.ts
@@ -1,5 +1,23 @@
-import {SpotifyPlaylist} from './SpotifyPlaylist';
+import {SpotifyPlaylist, SpotifyTrack} from './SpotifyPlaylist';
+
+export type SpotifyPlaylistsProps = {
+  selectPlaylist: (p: SpotifyPlaylist) => void;
+};
 
 export type SpotifyPlaylistProps = {
   spotifyPlaylist: SpotifyPlaylist;
+  selectPlaylist: (p: SpotifyPlaylist) => void;
+};
+
+export type BackButtonProps = {
+  unselectPlaylist: () => void;
+};
+
+export type SpotifyTracksProps = {
+  spotifyPlaylist: SpotifyPlaylist;
+  unselectPlaylist: () => void;
+};
+
+export type SpotifyTrackProps = {
+  spotifyTrack: SpotifyTrack;
 };


### PR DESCRIPTION
# Changes

## Initial Spotify Tracks implementation 71af47992831d63fb291640358d78ca88f07323f
- `src/App.tsx`
  - Set up switching between rendering of <Playlists> vs <SpotifyTracks> components
- `src/components/BackButton.tsx`
  - Add <BackButton> component
  - Button sets user from <SpotifyTracks> view back to <Playlists> view.
- `src/components/Playlist.tsx`
  - Add <Pressable> to handle playlist selection
- `src/components/Playlists.tsx`
  - Add passing of SpotifyPlaylistsProps to <Playlist> component
- `src/components/SpotifyTracks.tsx`
  - Add component for rendering tracks of a selected Spotify playlist
- `src/components/Track.tsx`
  - Add component for rendering a single Spotify playlist track
- `src/services/trackService.ts`
  - Add service for fetching playlist tracks via Spotify API
- `src/types/SpotifyPlaylist.ts`
  - Added SpotifyTrack and SpotifyTrackResponse interfaces
  - Updated SpotifyPlaylist interface
- `src/types/SpotifyPlaylistProps.ts`
  - Add and update props to correspond with other changes

## Rename `PlaylistList` -> `Playlists` 951413c60a948bca2e94a9b7d588f893273aa51c & Rename `PlaylistItem` -> `Playlist` 785e167c542e6fdb16aa137230a61ae6f01e22dc
- Renamed files and component names within both commits

