### PR TITLE
Compare playlists

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,10 +57,6 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     marginBottom: 20,
   },
-  loginButton: {
-    backgroundColor: '#1ED760', // Spotify green color
-    alignItems: 'center',
-  },
 });
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,32 @@
-import {useState} from 'react';
+import {useState, useEffect} from 'react';
 import AuthButton from './components/AuthButton';
 import {useAuth} from './contexts/AuthContext';
 import {SpotifyPlaylist} from './types/SpotifyPlaylist';
 import Playlists from './components/Playlists';
 import Tracks from './components/Tracks';
 import TracksComparison from './components/TracksComparison';
-import BackButton from './components/BackButton';
+import BackToPlaylistsButton from './components/BackToPlaylistsButton';
+
+type Screen = 'playlists' | 'tracks' | 'compare';
 
 function App(): React.JSX.Element {
   const isAuthenticated = useAuth();
+  const [screen, setScreen] = useState<Screen>('playlists');
   const [selectedPlaylists, setSelectedPlaylists] = useState<SpotifyPlaylist[]>(
     [],
   );
   const [focusedPlaylist, setFocusedPlaylist] =
     useState<SpotifyPlaylist | null>(null);
+
+  useEffect(() => {
+    if (focusedPlaylist) {
+      setScreen('tracks');
+    } else if (selectedPlaylists.length === 2) {
+      setScreen('compare');
+    } else {
+      setScreen('playlists');
+    }
+  }, [focusedPlaylist, selectedPlaylists]);
 
   const clearAllPlaylists = () => {
     setSelectedPlaylists([]);
@@ -32,33 +45,28 @@ function App(): React.JSX.Element {
   };
 
   const renderScreen = () => {
-    if (focusedPlaylist) {
-      return (
-        <>
-          <BackButton clearAllPlaylists={clearAllPlaylists} />
-          <Tracks spotifyPlaylist={focusedPlaylist} />
-        </>
-      );
+    switch (screen) {
+      case 'tracks':
+        return <Tracks spotifyPlaylist={focusedPlaylist!} />;
+      case 'compare':
+        return <TracksComparison selectedPlaylists={selectedPlaylists} />;
+      case 'playlists':
+      default:
+        return (
+          <Playlists
+            selectedPlaylists={selectedPlaylists}
+            updateSelectedPlaylists={updateSelectedPlaylists}
+            focusPlaylist={p => setFocusedPlaylist(p)}
+          />
+        );
     }
-    if (selectedPlaylists.length === 2) {
-      return (
-        <>
-          <BackButton clearAllPlaylists={clearAllPlaylists} />
-          <TracksComparison selectedPlaylists={selectedPlaylists} />
-        </>
-      );
-    }
-    return (
-      <Playlists
-        selectedPlaylists={selectedPlaylists}
-        updateSelectedPlaylists={updateSelectedPlaylists}
-        focusPlaylist={p => setFocusedPlaylist(p)}
-      />
-    );
   };
 
   return (
     <>
+      {isAuthenticated && screen !== 'playlists' && (
+        <BackToPlaylistsButton clearAllPlaylists={clearAllPlaylists} />
+      )}
       {isAuthenticated && renderScreen()}
       <AuthButton clearAllPlaylists={clearAllPlaylists} />
     </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import {useState} from 'react';
-import {StyleSheet, Text} from 'react-native';
 import AuthButton from './components/AuthButton';
 import {useAuth} from './contexts/AuthContext';
 import {SpotifyPlaylist} from './types/SpotifyPlaylist';
@@ -48,22 +47,10 @@ function App(): React.JSX.Element {
 
   return (
     <>
-      <Text style={styles.title}>
-        {focusedPlaylist ? `${focusedPlaylist.name} Tracks` : 'All Playlists'}
-      </Text>
       {isAuthenticated && tracksOrPlaylists()}
       <AuthButton clearAllPlaylists={clearAllPlaylists} />
     </>
   );
 }
-
-const styles = StyleSheet.create({
-  title: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    textAlign: 'center',
-    marginBottom: 20,
-  },
-});
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import {useAuth} from './contexts/AuthContext';
 import {SpotifyPlaylist} from './types/SpotifyPlaylist';
 import Playlists from './components/Playlists';
 import Tracks from './components/Tracks';
+import TracksComparison from './components/TracksComparison';
+import BackButton from './components/BackButton';
 
 function App(): React.JSX.Element {
   const isAuthenticated = useAuth();
@@ -29,14 +31,24 @@ function App(): React.JSX.Element {
     });
   };
 
-  const tracksOrPlaylists = () => {
-    // If a playlist is "focused", return <Tracks>; otherwise, return <Playlists>
-    return focusedPlaylist ? (
-      <Tracks
-        spotifyPlaylist={focusedPlaylist}
-        unfocusPlaylist={() => setFocusedPlaylist(null)}
-      />
-    ) : (
+  const renderScreen = () => {
+    if (focusedPlaylist) {
+      return (
+        <>
+          <BackButton clearAllPlaylists={clearAllPlaylists} />
+          <Tracks spotifyPlaylist={focusedPlaylist} />
+        </>
+      );
+    }
+    if (selectedPlaylists.length === 2) {
+      return (
+        <>
+          <BackButton clearAllPlaylists={clearAllPlaylists} />
+          <TracksComparison selectedPlaylists={selectedPlaylists} />
+        </>
+      );
+    }
+    return (
       <Playlists
         selectedPlaylists={selectedPlaylists}
         updateSelectedPlaylists={updateSelectedPlaylists}
@@ -47,7 +59,7 @@ function App(): React.JSX.Element {
 
   return (
     <>
-      {isAuthenticated && tracksOrPlaylists()}
+      {isAuthenticated && renderScreen()}
       <AuthButton clearAllPlaylists={clearAllPlaylists} />
     </>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,17 +8,36 @@ import Tracks from './components/Tracks';
 
 function App(): React.JSX.Element {
   const isAuthenticated = useAuth();
-  const [playlist, setPlaylist] = useState<SpotifyPlaylist | null>(null);
+  const [selectedPlaylists, setSelectedPlaylists] = useState<SpotifyPlaylist[]>(
+    [],
+  );
+  const [focusedPlaylist, setFocusedPlaylist] =
+    useState<SpotifyPlaylist | null>(null);
+
+  const updateSelectedPlaylists = (playlist: SpotifyPlaylist) => {
+    setSelectedPlaylists(prev => {
+      // if a previously selected playlist is being unselected
+      if (prev.some(p => p.id === playlist.id))
+        return prev.filter(p => p.id !== playlist.id);
+      // Don't allow for more than two selectedPlaylists
+      if (prev.length >= 2) return prev;
+      return [...prev, playlist];
+    });
+  };
 
   const tracksOrPlaylists = () => {
-    // If a playlist is selected, return <Tracks>; otherwise, return <Playlists>
-    return playlist ? (
+    // If a playlist is "focused", return <Tracks>; otherwise, return <Playlists>
+    return focusedPlaylist ? (
       <Tracks
-        spotifyPlaylist={playlist}
-        unselectPlaylist={() => setPlaylist(null)}
+        spotifyPlaylist={focusedPlaylist}
+        unfocusPlaylist={() => setFocusedPlaylist(null)}
       />
     ) : (
-      <Playlists selectPlaylist={(p: SpotifyPlaylist) => setPlaylist(p)} />
+      <Playlists
+        selectedPlaylists={selectedPlaylists}
+        updateSelectedPlaylists={updateSelectedPlaylists}
+        focusPlaylist={p => setFocusedPlaylist(p)}
+      />
     );
   };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,11 @@ function App(): React.JSX.Element {
   const [focusedPlaylist, setFocusedPlaylist] =
     useState<SpotifyPlaylist | null>(null);
 
+  const clearAllPlaylists = () => {
+    setSelectedPlaylists([]);
+    setFocusedPlaylist(null);
+  };
+
   const updateSelectedPlaylists = (playlist: SpotifyPlaylist) => {
     setSelectedPlaylists(prev => {
       // if a previously selected playlist is being unselected
@@ -45,7 +50,7 @@ function App(): React.JSX.Element {
     <>
       <Text style={styles.title}>SuperSetList</Text>
       {isAuthenticated && tracksOrPlaylists()}
-      <AuthButton />
+      <AuthButton clearAllPlaylists={clearAllPlaylists} />
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,7 +48,9 @@ function App(): React.JSX.Element {
 
   return (
     <>
-      <Text style={styles.title}>SuperSetList</Text>
+      <Text style={styles.title}>
+        {focusedPlaylist ? `${focusedPlaylist.name} Tracks` : 'All Playlists'}
+      </Text>
       {isAuthenticated && tracksOrPlaylists()}
       <AuthButton clearAllPlaylists={clearAllPlaylists} />
     </>

--- a/src/components/AuthButton.tsx
+++ b/src/components/AuthButton.tsx
@@ -1,4 +1,5 @@
 import {Pressable, StyleSheet, Text} from 'react-native';
+import {SPOTIFY_GREEN} from '../theme/colors';
 import {useAuth} from '../contexts/AuthContext';
 
 export default function AuthButton() {
@@ -20,7 +21,7 @@ const styles = StyleSheet.create({
   loginButton: {
     alignSelf: 'center',
     alignItems: 'center',
-    backgroundColor: '#1ED760', // Spotify green color
+    backgroundColor: SPOTIFY_GREEN,
     padding: 10,
     borderRadius: 8,
     width: '95%',

--- a/src/components/AuthButton.tsx
+++ b/src/components/AuthButton.tsx
@@ -1,12 +1,18 @@
 import {Pressable, StyleSheet, Text} from 'react-native';
 import {SPOTIFY_GREEN} from '../theme/colors';
 import {useAuth} from '../contexts/AuthContext';
+import {AuthButtonProps} from '../types/SpotifyPlaylistProps';
 
-export default function AuthButton() {
+export default function AuthButton({clearAllPlaylists}: AuthButtonProps) {
   const {login, logout, isAuthenticated} = useAuth();
 
   const handleOnPress = () => {
-    isAuthenticated ? logout() : login();
+    if (isAuthenticated) {
+      clearAllPlaylists();
+      logout();
+    } else {
+      login();
+    }
   };
   return (
     <Pressable onPress={handleOnPress} style={styles.loginButton}>

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -2,9 +2,9 @@ import {Pressable, StyleSheet, Text} from 'react-native';
 import {SPOTIFY_GREEN} from '../theme/colors';
 import {BackButtonProps} from '../types/SpotifyPlaylistProps';
 
-export default function BackButton({unfocusPlaylist}: BackButtonProps) {
+export default function BackButton({clearAllPlaylists}: BackButtonProps) {
   return (
-    <Pressable onPress={unfocusPlaylist} style={styles.loginButton}>
+    <Pressable onPress={clearAllPlaylists} style={styles.loginButton}>
       <Text style={{color: 'black', fontWeight: 'bold'}}>
         {'Return to Playlists'}
       </Text>

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -1,4 +1,5 @@
 import {Pressable, StyleSheet, Text} from 'react-native';
+import {SPOTIFY_GREEN} from '../theme/colors';
 import {BackButtonProps} from '../types/SpotifyPlaylistProps';
 
 export default function BackButton({unfocusPlaylist}: BackButtonProps) {
@@ -15,7 +16,7 @@ const styles = StyleSheet.create({
   loginButton: {
     alignSelf: 'center',
     alignItems: 'center',
-    backgroundColor: '#1ED760', // Spotify green color
+    backgroundColor: SPOTIFY_GREEN,
     padding: 10,
     borderRadius: 8,
     width: '95%',

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -1,9 +1,9 @@
 import {Pressable, StyleSheet, Text} from 'react-native';
 import {BackButtonProps} from '../types/SpotifyPlaylistProps';
 
-export default function BackButton({unselectPlaylist}: BackButtonProps) {
+export default function BackButton({unfocusPlaylist}: BackButtonProps) {
   return (
-    <Pressable onPress={unselectPlaylist} style={styles.loginButton}>
+    <Pressable onPress={unfocusPlaylist} style={styles.loginButton}>
       <Text style={{color: 'black', fontWeight: 'bold'}}>
         {'Return to Playlists'}
       </Text>

--- a/src/components/BackToPlaylistsButton.tsx
+++ b/src/components/BackToPlaylistsButton.tsx
@@ -1,8 +1,10 @@
 import {Pressable, StyleSheet, Text} from 'react-native';
 import {SPOTIFY_GREEN} from '../theme/colors';
-import {BackButtonProps} from '../types/SpotifyPlaylistProps';
+import {BackToPlaylistsButtonProps} from '../types/SpotifyPlaylistProps';
 
-export default function BackButton({clearAllPlaylists}: BackButtonProps) {
+export default function BackToPlaylistsButton({
+  clearAllPlaylists,
+}: BackToPlaylistsButtonProps) {
   return (
     <Pressable onPress={clearAllPlaylists} style={styles.loginButton}>
       <Text style={{color: 'black', fontWeight: 'bold'}}>

--- a/src/components/ListHeader.tsx
+++ b/src/components/ListHeader.tsx
@@ -1,0 +1,33 @@
+import {StyleSheet, Text, View, Image} from 'react-native';
+import {ListHeaderProps} from '../types/SpotifyPlaylistProps';
+import {useAuth} from '../contexts/AuthContext';
+
+export default function ListHeader({spotifyPlaylist}: ListHeaderProps) {
+  const {isAuthenticated} = useAuth();
+
+  const getTitle = () => {
+    if (!isAuthenticated) {
+      return 'SuperSetlist';
+    }
+    return spotifyPlaylist ? `${spotifyPlaylist.name} Tracks` : 'All Playlists';
+  };
+  return (
+    <View style={styles.header}>
+      <Image
+        source={{uri: spotifyPlaylist?.images[0].url}}
+        style={{width: 50, height: 50, borderRadius: 50 / 2}}
+      />
+      <Text style={styles.title}>{getTitle()}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {alignItems: 'center'},
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    textAlign: 'center',
+    marginBottom: 20,
+  },
+});

--- a/src/components/Playlist.tsx
+++ b/src/components/Playlist.tsx
@@ -1,4 +1,5 @@
 import {Image, Pressable, StyleSheet, Text, View} from 'react-native';
+import {PLAYLIST_BG} from '../theme/colors';
 import {SpotifyPlaylistProps} from '../types/SpotifyPlaylistProps';
 
 export default function Playlist({
@@ -8,8 +9,8 @@ export default function Playlist({
   focusPlaylist,
 }: SpotifyPlaylistProps) {
   const getBackgroundColor = (pressed: boolean) => {
-    if (pressed) return 'rgb(210, 230, 255)';
-    return isSelected ? '#1ED760' : 'white';
+    if (pressed) return PLAYLIST_BG.pressed;
+    return isSelected ? PLAYLIST_BG.selected : PLAYLIST_BG.default;
   };
   return (
     <Pressable

--- a/src/components/Playlist.tsx
+++ b/src/components/Playlist.tsx
@@ -3,14 +3,21 @@ import {SpotifyPlaylistProps} from '../types/SpotifyPlaylistProps';
 
 export default function Playlist({
   spotifyPlaylist,
-  selectPlaylist,
+  isSelected,
+  updateSelectedPlaylists,
+  focusPlaylist,
 }: SpotifyPlaylistProps) {
+  const getBackgroundColor = (pressed: boolean) => {
+    if (pressed) return 'rgb(210, 230, 255)';
+    return isSelected ? '#1ED760' : 'white';
+  };
   return (
     <Pressable
-      onPress={() => selectPlaylist(spotifyPlaylist)}
+      onPress={() => updateSelectedPlaylists(spotifyPlaylist)}
+      onLongPress={() => focusPlaylist(spotifyPlaylist)}
       style={({pressed}) => [
         {
-          backgroundColor: pressed ? 'rgb(210, 230, 255)' : 'white',
+          backgroundColor: getBackgroundColor(pressed),
         },
       ]}>
       <View style={styles.container}>

--- a/src/components/Playlists.tsx
+++ b/src/components/Playlists.tsx
@@ -3,6 +3,7 @@ import {SpotifyPlaylist} from '../types/SpotifyPlaylist';
 import {SpotifyPlaylistsProps} from '../types/SpotifyPlaylistProps';
 import {getPlaylists} from '../services/playlistService';
 import Playlist from './Playlist';
+import ListHeader from './ListHeader';
 import {useAuth} from '../contexts/AuthContext';
 
 export default function Playlists({
@@ -28,6 +29,7 @@ export default function Playlists({
 
   return (
     <>
+      <ListHeader />
       {playlists &&
         playlists.map(playlist => {
           return (

--- a/src/components/Playlists.tsx
+++ b/src/components/Playlists.tsx
@@ -5,7 +5,11 @@ import {getPlaylists} from '../services/playlistService';
 import Playlist from './Playlist';
 import {useAuth} from '../contexts/AuthContext';
 
-export default function Playlists({selectPlaylist}: SpotifyPlaylistsProps) {
+export default function Playlists({
+  selectedPlaylists,
+  updateSelectedPlaylists,
+  focusPlaylist,
+}: SpotifyPlaylistsProps) {
   const [playlists, setPlaylists] = useState<SpotifyPlaylist[] | null>(null);
   const {auth} = useAuth();
   const accessToken = auth?.accessToken;
@@ -30,7 +34,9 @@ export default function Playlists({selectPlaylist}: SpotifyPlaylistsProps) {
             <Playlist
               key={playlist.id}
               spotifyPlaylist={playlist}
-              selectPlaylist={selectPlaylist}
+              isSelected={!!selectedPlaylists.some(p => p.id === playlist.id)}
+              updateSelectedPlaylists={updateSelectedPlaylists}
+              focusPlaylist={focusPlaylist}
             />
           );
         })}

--- a/src/components/Playlists.tsx
+++ b/src/components/Playlists.tsx
@@ -5,6 +5,7 @@ import {getPlaylists} from '../services/playlistService';
 import Playlist from './Playlist';
 import ListHeader from './ListHeader';
 import {useAuth} from '../contexts/AuthContext';
+import {FlatList} from 'react-native';
 
 export default function Playlists({
   selectedPlaylists,
@@ -30,18 +31,18 @@ export default function Playlists({
   return (
     <>
       <ListHeader />
-      {playlists &&
-        playlists.map(playlist => {
-          return (
-            <Playlist
-              key={playlist.id}
-              spotifyPlaylist={playlist}
-              isSelected={!!selectedPlaylists.some(p => p.id === playlist.id)}
-              updateSelectedPlaylists={updateSelectedPlaylists}
-              focusPlaylist={focusPlaylist}
-            />
-          );
-        })}
+      <FlatList
+        data={playlists}
+        renderItem={({item}) => (
+          <Playlist
+            spotifyPlaylist={item}
+            isSelected={!!selectedPlaylists.some(p => p.id === item.id)}
+            updateSelectedPlaylists={updateSelectedPlaylists}
+            focusPlaylist={focusPlaylist}
+          />
+        )}
+        keyExtractor={item => item.id}
+      />
     </>
   );
 }

--- a/src/components/Track.tsx
+++ b/src/components/Track.tsx
@@ -1,12 +1,21 @@
 import {Image, StyleSheet, Text, View} from 'react-native';
 import {SpotifyTrackProps} from '../types/SpotifyPlaylistProps';
 
-export default function Track({spotifyTrack}: SpotifyTrackProps) {
+const IMAGE_SIZE_MAP = {
+  small: 65,
+  large: 100,
+};
+
+export default function Track({
+  spotifyTrack,
+  size = 'large',
+}: SpotifyTrackProps) {
+  const imageSize = IMAGE_SIZE_MAP[size];
   return (
     <View style={styles.container}>
       <Image
         source={{uri: spotifyTrack.album.images[0]?.url}}
-        style={{width: 100, height: 100}}
+        style={{width: imageSize, height: imageSize}}
       />
       <View style={styles.textContainer}>
         <Text style={styles.name}>{spotifyTrack.name}</Text>

--- a/src/components/Tracks.tsx
+++ b/src/components/Tracks.tsx
@@ -4,13 +4,10 @@ import Track from './Track';
 import {SpotifyTracksProps} from '../types/SpotifyPlaylistProps';
 import {getPlaylistTracks} from '../services/trackService';
 import {useAuth} from '../contexts/AuthContext';
-import BackButton from './BackButton';
 import ListHeader from './ListHeader';
+import {View, StyleSheet} from 'react-native';
 
-export default function Tracks({
-  spotifyPlaylist,
-  unfocusPlaylist,
-}: SpotifyTracksProps) {
+export default function Tracks({spotifyPlaylist}: SpotifyTracksProps) {
   const [tracks, setTracks] = useState<SpotifyTrack[] | null>(null);
   const {auth} = useAuth();
   const accessToken = auth?.accessToken;
@@ -27,13 +24,18 @@ export default function Tracks({
   }, [accessToken]);
 
   return (
-    <>
+    <View style={styles.column}>
       <ListHeader spotifyPlaylist={spotifyPlaylist} />
-      <BackButton unfocusPlaylist={unfocusPlaylist} />
       {tracks &&
         tracks.map(track => {
           return <Track key={track.id} spotifyTrack={track} />;
         })}
-    </>
+    </View>
   );
 }
+
+const styles = StyleSheet.create({
+  column: {
+    flex: 1,
+  },
+});

--- a/src/components/Tracks.tsx
+++ b/src/components/Tracks.tsx
@@ -8,7 +8,7 @@ import BackButton from './BackButton';
 
 export default function Tracks({
   spotifyPlaylist,
-  unselectPlaylist,
+  unfocusPlaylist,
 }: SpotifyTracksProps) {
   const [tracks, setTracks] = useState<SpotifyTrack[] | null>(null);
   const {auth} = useAuth();
@@ -27,7 +27,7 @@ export default function Tracks({
 
   return (
     <>
-      <BackButton unselectPlaylist={unselectPlaylist} />
+      <BackButton unfocusPlaylist={unfocusPlaylist} />
       {tracks &&
         tracks.map(track => {
           return <Track key={track.id} spotifyTrack={track} />;

--- a/src/components/Tracks.tsx
+++ b/src/components/Tracks.tsx
@@ -5,7 +5,7 @@ import {SpotifyTracksProps} from '../types/SpotifyPlaylistProps';
 import {getPlaylistTracks} from '../services/trackService';
 import {useAuth} from '../contexts/AuthContext';
 import ListHeader from './ListHeader';
-import {View, StyleSheet} from 'react-native';
+import {View, StyleSheet, FlatList} from 'react-native';
 
 export default function Tracks({spotifyPlaylist}: SpotifyTracksProps) {
   const [tracks, setTracks] = useState<SpotifyTrack[] | null>(null);
@@ -26,10 +26,11 @@ export default function Tracks({spotifyPlaylist}: SpotifyTracksProps) {
   return (
     <View style={styles.column}>
       <ListHeader spotifyPlaylist={spotifyPlaylist} />
-      {tracks &&
-        tracks.map(track => {
-          return <Track key={track.id} spotifyTrack={track} />;
-        })}
+      <FlatList
+        data={tracks}
+        renderItem={({item}) => <Track spotifyTrack={item} />}
+        keyExtractor={item => item.id}
+      />
     </View>
   );
 }

--- a/src/components/Tracks.tsx
+++ b/src/components/Tracks.tsx
@@ -5,6 +5,7 @@ import {SpotifyTracksProps} from '../types/SpotifyPlaylistProps';
 import {getPlaylistTracks} from '../services/trackService';
 import {useAuth} from '../contexts/AuthContext';
 import BackButton from './BackButton';
+import ListHeader from './ListHeader';
 
 export default function Tracks({
   spotifyPlaylist,
@@ -27,6 +28,7 @@ export default function Tracks({
 
   return (
     <>
+      <ListHeader spotifyPlaylist={spotifyPlaylist} />
       <BackButton unfocusPlaylist={unfocusPlaylist} />
       {tracks &&
         tracks.map(track => {

--- a/src/components/Tracks.tsx
+++ b/src/components/Tracks.tsx
@@ -7,7 +7,10 @@ import {useAuth} from '../contexts/AuthContext';
 import ListHeader from './ListHeader';
 import {View, StyleSheet, FlatList} from 'react-native';
 
-export default function Tracks({spotifyPlaylist}: SpotifyTracksProps) {
+export default function Tracks({
+  spotifyPlaylist,
+  size = 'large',
+}: SpotifyTracksProps) {
   const [tracks, setTracks] = useState<SpotifyTrack[] | null>(null);
   const {auth} = useAuth();
   const accessToken = auth?.accessToken;
@@ -28,7 +31,7 @@ export default function Tracks({spotifyPlaylist}: SpotifyTracksProps) {
       <ListHeader spotifyPlaylist={spotifyPlaylist} />
       <FlatList
         data={tracks}
-        renderItem={({item}) => <Track spotifyTrack={item} />}
+        renderItem={({item}) => <Track spotifyTrack={item} size={size} />}
         keyExtractor={item => item.id}
       />
     </View>

--- a/src/components/TracksComparison.tsx
+++ b/src/components/TracksComparison.tsx
@@ -16,5 +16,6 @@ export default function TracksComparison({
 const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
+    flex: 1,
   },
 });

--- a/src/components/TracksComparison.tsx
+++ b/src/components/TracksComparison.tsx
@@ -1,0 +1,20 @@
+import Tracks from './Tracks';
+import {SpotifyTracksComparisonProps} from '../types/SpotifyPlaylistProps';
+import {View, StyleSheet} from 'react-native';
+
+export default function TracksComparison({
+  selectedPlaylists,
+}: SpotifyTracksComparisonProps) {
+  return (
+    <View style={styles.container}>
+      <Tracks spotifyPlaylist={selectedPlaylists[0]} />
+      <Tracks spotifyPlaylist={selectedPlaylists[1]} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+  },
+});

--- a/src/components/TracksComparison.tsx
+++ b/src/components/TracksComparison.tsx
@@ -7,8 +7,8 @@ export default function TracksComparison({
 }: SpotifyTracksComparisonProps) {
   return (
     <View style={styles.container}>
-      <Tracks spotifyPlaylist={selectedPlaylists[0]} />
-      <Tracks spotifyPlaylist={selectedPlaylists[1]} />
+      <Tracks spotifyPlaylist={selectedPlaylists[0]} size={'small'} />
+      <Tracks spotifyPlaylist={selectedPlaylists[1]} size={'small'} />
     </View>
   );
 }

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,0 +1,7 @@
+export const SPOTIFY_GREEN = '#1ED760';
+
+export const PLAYLIST_BG = {
+  default: 'white',
+  selected: SPOTIFY_GREEN,
+  pressed: 'grey',
+};

--- a/src/types/SpotifyPlaylistProps.ts
+++ b/src/types/SpotifyPlaylistProps.ts
@@ -1,21 +1,26 @@
 import {SpotifyPlaylist, SpotifyTrack} from './SpotifyPlaylist';
 
-export type SpotifyPlaylistsProps = {
-  selectPlaylist: (p: SpotifyPlaylist) => void;
+type SpotifyPlaylistActions = {
+  updateSelectedPlaylists: (p: SpotifyPlaylist) => void;
+  focusPlaylist: (p: SpotifyPlaylist) => void;
 };
 
-export type SpotifyPlaylistProps = {
+export type SpotifyPlaylistsProps = SpotifyPlaylistActions & {
+  selectedPlaylists: SpotifyPlaylist[];
+};
+
+export type SpotifyPlaylistProps = SpotifyPlaylistActions & {
   spotifyPlaylist: SpotifyPlaylist;
-  selectPlaylist: (p: SpotifyPlaylist) => void;
+  isSelected: boolean;
 };
 
 export type BackButtonProps = {
-  unselectPlaylist: () => void;
+  unfocusPlaylist: () => void;
 };
 
 export type SpotifyTracksProps = {
   spotifyPlaylist: SpotifyPlaylist;
-  unselectPlaylist: () => void;
+  unfocusPlaylist: () => void;
 };
 
 export type SpotifyTrackProps = {

--- a/src/types/SpotifyPlaylistProps.ts
+++ b/src/types/SpotifyPlaylistProps.ts
@@ -16,6 +16,7 @@ export type SpotifyPlaylistProps = SpotifyPlaylistActions & {
 
 export type SpotifyTracksProps = {
   spotifyPlaylist: SpotifyPlaylist;
+  size?: 'small' | 'large';
 };
 
 export type SpotifyTracksComparisonProps = {
@@ -24,6 +25,7 @@ export type SpotifyTracksComparisonProps = {
 
 export type SpotifyTrackProps = {
   spotifyTrack: SpotifyTrack;
+  size?: 'small' | 'large';
 };
 
 export type AuthButtonProps = {

--- a/src/types/SpotifyPlaylistProps.ts
+++ b/src/types/SpotifyPlaylistProps.ts
@@ -14,10 +14,6 @@ export type SpotifyPlaylistProps = SpotifyPlaylistActions & {
   isSelected: boolean;
 };
 
-export type BackButtonProps = {
-  unfocusPlaylist: () => void;
-};
-
 export type SpotifyTracksProps = {
   spotifyPlaylist: SpotifyPlaylist;
   unfocusPlaylist: () => void;
@@ -25,4 +21,12 @@ export type SpotifyTracksProps = {
 
 export type SpotifyTrackProps = {
   spotifyTrack: SpotifyTrack;
+};
+
+export type AuthButtonProps = {
+  clearAllPlaylists: () => void;
+};
+
+export type BackButtonProps = {
+  unfocusPlaylist: () => void;
 };

--- a/src/types/SpotifyPlaylistProps.ts
+++ b/src/types/SpotifyPlaylistProps.ts
@@ -30,3 +30,7 @@ export type AuthButtonProps = {
 export type BackButtonProps = {
   unfocusPlaylist: () => void;
 };
+
+export type ListHeaderProps = {
+  spotifyPlaylist?: SpotifyPlaylist;
+};

--- a/src/types/SpotifyPlaylistProps.ts
+++ b/src/types/SpotifyPlaylistProps.ts
@@ -30,7 +30,7 @@ export type AuthButtonProps = {
   clearAllPlaylists: () => void;
 };
 
-export type BackButtonProps = {
+export type BackToPlaylistsButtonProps = {
   clearAllPlaylists: () => void;
 };
 

--- a/src/types/SpotifyPlaylistProps.ts
+++ b/src/types/SpotifyPlaylistProps.ts
@@ -16,7 +16,10 @@ export type SpotifyPlaylistProps = SpotifyPlaylistActions & {
 
 export type SpotifyTracksProps = {
   spotifyPlaylist: SpotifyPlaylist;
-  unfocusPlaylist: () => void;
+};
+
+export type SpotifyTracksComparisonProps = {
+  selectedPlaylists: SpotifyPlaylist[];
 };
 
 export type SpotifyTrackProps = {
@@ -28,7 +31,7 @@ export type AuthButtonProps = {
 };
 
 export type BackButtonProps = {
-  unfocusPlaylist: () => void;
+  clearAllPlaylists: () => void;
 };
 
 export type ListHeaderProps = {


### PR DESCRIPTION
# Proposed Changes
#### - [Update onPress/onLongPress behaviour for Playlist](https://github.com/aaronskiba/SuperSetList/commit/b041ee102cd4397be517b5daf8b598c91742b5a4)
`src/App.tsx`
- Add `[selectedPlaylists, setSelectedPlaylists]` to allow selection of two playlists (will be used for implementing comparison between them
- Add `def updateSelectedPlaylists` to handle the selection/unselection of playlists

`src/components/Playlist.tsx`
- Add additional logic to handle backgroundColor when a playlist is pressed or selected
- Use onPress for playlist selection and onLongPress for switching to 'tracks view'

#### - [Refactor colors / create src/theme/colors.ts](https://github.com/aaronskiba/SuperSetList/commit/a9e9d7a436edee37cfebbf18903af1258ed1f475)
Also removed some unused styling code from App.tsx

#### - [Clear selected & focused playlists on logout](https://github.com/aaronskiba/SuperSetList/commit/0d9ecc96110c05e489e658616c6af85513d87160)

#### - [Update rendering logic of Playlist/Playlists title](https://github.com/aaronskiba/SuperSetList/commit/0a074d7daf54b4c094b668218ed72b15709641ca)
Render title as `${focusedPlaylist.name} Tracks` when we are focused on a playlist. Otherwise, render 'All Playlists'.

#### - [Create ListHeader component & refactor](https://github.com/aaronskiba/SuperSetList/commit/799a8ebd06c14ab3a95944d874ac1ce6e71b59dc)
Also expanded on changes in commit 4cfe3f1ab3df12ccb3a1d63c9deb6e1e6455ab48 so that the "SuperSetlist" is rendered when the user is not authenticated.

#### - [Initial TracksComparison implementation](https://github.com/aaronskiba/SuperSetList/commit/58b6b8d57a2f0961a664546253f2508c20672391)
This change introduces the `TracksComparison` component. When two separate playlists are selected, `TracksComparison` is rendered to provide a side-by-side view of the selected playlists.

`src/App.tsx`
- `tracksOrPlaylists` has been updated to `renderScreen`, which now handles rendering either `Tracks`, `TracksComparison`, or `Playlists`.
- Refactored so that `BackButton` is now handled in this component.

`src/components/BackButton.tsx`
- Updated onPress logic to clear both `focusedPlaylist` and `selectedPlaylists`

`src/components/Tracks.tsx`
- Removed BackButton and unfocusPlaylist prop
- Wrapped Tracks content in a View so it can be laid out as a direct child in TracksComparison (flex layout styling was not working with fragments)

#### - [Refactor: Centralize screen state in App.tsx](https://github.com/aaronskiba/SuperSetList/commit/b78e315a0859d58f4aa4d138991d0e5076adeed1)
This refactor centralizes screen state and simplifies rendering logic via the `screen` state.

- Added `screen` state to App.tsx to capture 'playlists', 'tracks', and 'compare' views.
- Added useEffect to derive the `screen` from `focusedPlaylist` and `selectedPlaylist`.
- Renamed BackButton to BackToPlaylistsButton for clarity.

#### - [Make Tracks and Playlists scrollable](https://github.com/aaronskiba/SuperSetList/commit/b4e08036311f57142747e2612f0bfd68cac25eb2)
This change uses FlatList to make the `Playlists` and `Tracks` items scrollable.

#### - [Add optional size prop to Track](https://github.com/aaronskiba/SuperSetList/commit/c2eb71138fbe8f1f5f1fadabcb4b185b41094315)
Adding an optional `size` prop to Track allows for more user-friendly displays between the Tracks and TracksComparision views.
- Set `size = 'large'` as default (TracksComparison passes `size={'small'}`).
- This change required also adding an optional `size` prop to Tracks.
- Added logic in Track component so that Image size is determined by the value of `size` prop
